### PR TITLE
Settings: Add build user and host to build date

### DIFF
--- a/src/com/android/settings/deviceinfo/firmwareversion/LineageBuildDatePreferenceController.java
+++ b/src/com/android/settings/deviceinfo/firmwareversion/LineageBuildDatePreferenceController.java
@@ -28,6 +28,9 @@ public class LineageBuildDatePreferenceController extends BasePreferenceControll
 
     private static final String KEY_BUILD_DATE_PROP = "ro.build.date";
 
+    private static final String KEY_BUILD_HOST_PROP = "ro.build.host";
+    private static final String KEY_BUILD_USER_PROP = "ro.build.user";
+
     public LineageBuildDatePreferenceController(Context context, String key) {
         super(context, key);
     }
@@ -39,7 +42,11 @@ public class LineageBuildDatePreferenceController extends BasePreferenceControll
 
     @Override
     public CharSequence getSummary() {
-        return SystemProperties.get(KEY_BUILD_DATE_PROP,
-                mContext.getString(R.string.unknown));
+        return SystemProperties.get(KEY_BUILD_DATE_PROP, mContext.getString(R.string.unknown))
+               + " (" 
+               + SystemProperties.get(KEY_BUILD_USER_PROP, mContext.getString(R.string.unknown))
+               + "@"
+               + SystemProperties.get(KEY_BUILD_HOST_PROP, mContext.getString(R.string.unknown))
+               + ")";
     }
 }


### PR DESCRIPTION
ビルド日時の項目にビルドユーザとビルドホストの表示を追加します。

9にまで実装していたカーネルバージョンに表示できていた物を10に簡易移植した感じです。

build.propからro.build.userとro.build.hostを引いています。
![cf9acfd567272081](https://user-images.githubusercontent.com/35889969/80974425-ac2cb280-8e5b-11ea-8b62-e58583bf36c4.png)
